### PR TITLE
Fixed device descriptior

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,7 +464,7 @@ const Good3G = {
   'latency': 40
 };
 
-const phone = devices['Nexus 5X'];
+const phone = devices.devicesMap['Nexus 5X'];
 
 function calcLCP() {
   window.largestContentfulPaint = 0;
@@ -547,7 +547,7 @@ const Good3G = {
   'latency': 40
 };
   
-const phone = devices['Nexus 5X'];
+const phone = devices.devicesMap['Nexus 5X'];
 
 function calcJank() {
   window.cumulativeLayoutShiftScore = 0;

--- a/cumulative-layout-shift.js
+++ b/cumulative-layout-shift.js
@@ -8,7 +8,7 @@ const Good3G = {
   'latency': 40,
 };
 
-const phone = devices['Nexus 5X'];
+const phone = devices.devicesMap['Nexus 5X'];
 
 /**
  * Measure layout shifts

--- a/largest-contentful-paint.js
+++ b/largest-contentful-paint.js
@@ -8,7 +8,7 @@ const Good3G = {
   'latency': 40,
 };
 
-const phone = devices['Nexus 5X'];
+const phone = devices.devicesMap['Nexus 5X'];
 
 /**
  * Measure LCP


### PR DESCRIPTION
## In this Pull Request

### Problem

When you run the script `cumulative-layout-shift.js` and `largest-contentful-paint.js` you get an error.

```sh
➜ node largest-contentful-paint.js
TypeError: Cannot read property 'viewport' of undefined
    at Page.emulate (/Users/joan.leon/projects/PerfReviews/.../puppeteer-webperf/node_modules/puppeteer/lib/Page.js:541:38)
    at Page.<anonymous> (/Users/joan.leon/projects/PerfReviews/.../puppeteer-webperf/node_modules/puppeteer/lib/helper.js:95:27)
    at getLCP (/Users/joan.leon/projects/PerfReviews/.../puppeteer-webperf/largest-contentful-paint.js:55:16)
    at processTicksAndRejections (internal/process/task_queues.js:93:5)
LCP is: undefined
```

This error is because the `DeviceDescriptors` export the devices inside `devicesMap` object.

### Solution

Add the key `devicesMap` to get devices, like:

```js
const phone = devices.devicesMap['Nexus 5X'];
```