### PR TITLE
Update to use page.emulateNetworkConditions

### DIFF
--- a/README.md
+++ b/README.md
@@ -277,8 +277,7 @@ lighthouseFromPuppeteer("https://bbc.com", options);
 
 <h3 id="throttle-network">Emulate a slow network</h3>
 
-If you need to throttle the network connection, use `page.emulateNetworkConditions`. You can find the available parameters
-in the <a href="https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pageemulatenetworkconditionsnetworkconditions">puppeteer documentation</a>.
+If you need to throttle the network connection, use [Puppeteer’s `page.emulateNetworkConditions` API](https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pageemulatenetworkconditionsnetworkconditions).
 
 🚨 Real network performance can be impacted by latency to towers, traffic patterns and the current radio activity. The <a href="https://github.com/GoogleChrome/lighthouse/blob/master/docs/throttling.md">Lighthouse guide to network throttling</a> covers in more detail what the differences are between simulated, request-level and packet-level throttling.
 

--- a/README.md
+++ b/README.md
@@ -277,7 +277,8 @@ lighthouseFromPuppeteer("https://bbc.com", options);
 
 <h3 id="throttle-network">Emulate a slow network</h3>
 
-If you need to throttle the network connection, use `Network.emulateNetworkConditions` via the Chrome DevTools Protocol. You can borrow configuration details for what is used in the DevTools Network panel for emulation details.
+If you need to throttle the network connection, use `page.emulateNetworkConditions`. You can find the available parameters
+in the <a href="https://github.com/puppeteer/puppeteer/blob/v8.0.0/docs/api.md#pageemulatenetworkconditionsnetworkconditions">puppeteer documentation</a>.
 
 🚨 Real network performance can be impacted by latency to towers, traffic patterns and the current radio activity. The <a href="https://github.com/GoogleChrome/lighthouse/blob/master/docs/throttling.md">Lighthouse guide to network throttling</a> covers in more detail what the differences are between simulated, request-level and packet-level throttling.
 
@@ -296,16 +297,7 @@ const puppeteer = require('puppeteer');
   const client = await page.target().createCDPSession();
   await client.send('Network.enable');
   // Simulated network throttling (Slow 3G)
-  await client.send('Network.emulateNetworkConditions', {
-    // Network connectivity is absent
-    'offline': false,
-    // Download speed (bytes/s)
-    'downloadThroughput': 500 * 1024 / 8 * .8,
-    // Upload speed (bytes/s)
-    'uploadThroughput': 500 * 1024 / 8 * .8,
-    // Latency (ms)
-    'latency': 400 * 5
-  });
+  await page.emulateNetworkConditions(puppeteer.networkConditions['Slow 3G']);
   await browser.close();
 })();
 ```
@@ -316,7 +308,7 @@ You can find details on the presets DevTools supports for Slow and Fast 3G in th
 
 <h3 id="throttle-network-cpu">Emulate a slow network and CPU</h3>
 
-CPU throttling allows you to simulate how a page performs on slower mobile devices. This can be done using `Network.emulateNetworkConditions` via the Chrome DevTools Protocol.
+CPU throttling allows you to simulate how a page performs on slower mobile devices. This can be done using `page.emulateNetworkConditions` via the Chrome DevTools Protocol.
 
 🚨 Real device CPU performance is impacted by many factors that are not trivial to emulate via the Chrome DevTools Protocol / Puppeteer. e.g core count, L1/L2 cache, thermal throttling impacting performance, architecture etc. Simulating CPU performance can be a good guideline, but ideally also verify any numbers you see on a real mobile device.
 
@@ -333,16 +325,7 @@ const puppeteer = require('puppeteer');
   const client = await page.target().createCDPSession();
   await client.send('Network.enable');
   // Simulated network throttling (Slow 3G)
-  await client.send('Network.emulateNetworkConditions', {
-    // Network connectivity is absent
-    'offline': false,
-    // Download speed (bytes/s)
-    'downloadThroughput': 500 * 1024 / 8 * .8,
-    // Upload speed (bytes/s)
-    'uploadThroughput': 500 * 1024 / 8 * .8,
-    // Latency (ms)
-    'latency': 400 * 5
-  });
+  await page.emulateNetworkConditions(puppeteer.networkConditions['Slow 3G']);
   await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
   await browser.close();
 })();
@@ -457,13 +440,6 @@ The Largest Contentful Paint (LCP) metric reports render time for the largest co
 const puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 
-const Good3G = {
-  'offline': false,
-  'downloadThroughput': 1.5 * 1024 * 1024 / 8,
-  'uploadThroughput': 750 * 1024 / 8,
-  'latency': 40
-};
-
 const phone = devices.devicesMap['Nexus 5X'];
 
 function calcLCP() {
@@ -499,7 +475,7 @@ async function getLCP(url) {
 
     await client.send('Network.enable');
     await client.send('ServiceWorker.enable');
-    await client.send('Network.emulateNetworkConditions', Good3G);
+    await page.emulateNetworkConditions(puppeteer.networkConditions['Good 3G']);
     await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
     await page.emulate(phone);
 
@@ -539,13 +515,6 @@ The Cumulative Layout Shift (CLS) metric measures the sum of individual layout s
 ```js
 const puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
-
-const Good3G = {
-  'offline': false,
-  'downloadThroughput': 1.5 * 1024 * 1024 / 8,
-  'uploadThroughput': 750 * 1024 / 8,
-  'latency': 40
-};
   
 const phone = devices.devicesMap['Nexus 5X'];
 
@@ -585,7 +554,7 @@ async function getCLS(url) {
 
     await client.send('Network.enable');
     await client.send('ServiceWorker.enable');
-    await client.send('Network.emulateNetworkConditions', Good3G);
+    await page.emulateNetworkConditions(puppeteer.networkConditions['Good 3G']);
     await client.send('Emulation.setCPUThrottlingRate', { rate: 4 });
     await page.emulate(phone);
     // inject a function with the code from 

--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ You can find details on the presets DevTools supports for Slow and Fast 3G in th
 
 <h3 id="throttle-network-cpu">Emulate a slow network and CPU</h3>
 
-CPU throttling allows you to simulate how a page performs on slower mobile devices. This can be done using `page.emulateNetworkConditions` via the Chrome DevTools Protocol.
+CPU throttling allows you to simulate how a page performs on slower mobile devices. This can be done using Puppeteer’s `page.emulateNetworkConditions` API.
 
 🚨 Real device CPU performance is impacted by many factors that are not trivial to emulate via the Chrome DevTools Protocol / Puppeteer. e.g core count, L1/L2 cache, thermal throttling impacting performance, architecture etc. Simulating CPU performance can be a good guideline, but ideally also verify any numbers you see on a real mobile device.
 

--- a/cumulative-layout-shift.js
+++ b/cumulative-layout-shift.js
@@ -1,13 +1,6 @@
 const puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 
-const Good3G = {
-  'offline': false,
-  'downloadThroughput': 1.5 * 1024 * 1024 / 8,
-  'uploadThroughput': 750 * 1024 / 8,
-  'latency': 40,
-};
-
 const phone = devices.devicesMap['Nexus 5X'];
 
 /**
@@ -54,7 +47,7 @@ async function getCLS(url) {
 
     await client.send('Network.enable');
     await client.send('ServiceWorker.enable');
-    await client.send('Network.emulateNetworkConditions', Good3G);
+    await page.emulateNetworkConditions(puppeteer.networkConditions['Good 3G']);
     await client.send('Emulation.setCPUThrottlingRate', {rate: 4});
     await page.emulate(phone);
     // inject a function with the code from

--- a/largest-contentful-paint.js
+++ b/largest-contentful-paint.js
@@ -50,7 +50,7 @@ async function getLCP(url) {
 
     await client.send('Network.enable');
     await client.send('ServiceWorker.enable');
-    await client.send('Network.emulateNetworkConditions', Good3G);
+    await page.emulateNetworkConditions(puppeteer.networkConditions['Good 3G']);
     await client.send('Emulation.setCPUThrottlingRate', {rate: 4});
     await page.emulate(phone);
 

--- a/largest-contentful-paint.js
+++ b/largest-contentful-paint.js
@@ -1,13 +1,6 @@
 const puppeteer = require('puppeteer');
 const devices = require('puppeteer/DeviceDescriptors');
 
-const Good3G = {
-  'offline': false,
-  'downloadThroughput': 1.5 * 1024 * 1024 / 8,
-  'uploadThroughput': 750 * 1024 / 8,
-  'latency': 40,
-};
-
 const phone = devices.devicesMap['Nexus 5X'];
 
 /**

--- a/throttle-network-cpu.js
+++ b/throttle-network-cpu.js
@@ -8,16 +8,7 @@ const puppeteer = require('puppeteer');
   const client = await page.target().createCDPSession();
   await client.send('Network.enable');
   // Simulated network throttling (Slow 3G)
-  await client.send('Network.emulateNetworkConditions', {
-    // Network connectivity is absent
-    'offline': false,
-    // Download speed (bytes/s)
-    'downloadThroughput': 500 * 1024 / 8 * .8,
-    // Upload speed (bytes/s)
-    'uploadThroughput': 500 * 1024 / 8 * .8,
-    // Latency (ms)
-    'latency': 400 * 5,
-  });
+  await page.emulateNetworkConditions(puppeteer.networkConditions['Slow 3G']);
   await client.send('Emulation.setCPUThrottlingRate', {rate: 4});
   await browser.close();
 })();

--- a/throttle-network.js
+++ b/throttle-network.js
@@ -7,15 +7,6 @@ const puppeteer = require('puppeteer');
   const client = await page.target().createCDPSession();
   await client.send('Network.enable');
   // Simulated network throttling (Slow 3G)
-  await client.send('Network.emulateNetworkConditions', {
-    // Network connectivity is absent
-    'offline': false,
-    // Download speed (bytes/s)
-    'downloadThroughput': 500 * 1024 / 8 * .8,
-    // Upload speed (bytes/s)
-    'uploadThroughput': 500 * 1024 / 8 * .8,
-    // Latency (ms)
-    'latency': 400 * 5,
-  });
+  await page.emulateNetworkConditions(puppeteer.networkConditions['Slow 3G']);
   await browser.close();
 })();


### PR DESCRIPTION
This patch updates all call sites of the
`Network.emulateNetworkConditions` CDP command to the
new `page.emulateNetworkConditions` api on page.